### PR TITLE
Fixes compilation error for MT4 Oscillators and Indicators.

### DIFF
--- a/Oscillators/AC.mq4
+++ b/Oscillators/AC.mq4
@@ -23,12 +23,21 @@
 // Indicator properties.
 #ifdef __MQL__
 #property indicator_separate_window
-#property indicator_buffers 3
-#property indicator_color1 Black
-#property indicator_color2 Green
-#property indicator_color3 Red
+#property indicator_buffers 1
+#property indicator_plots 1
+#property indicator_type1 DRAW_LINE
+#property indicator_color1 Green
+#property indicator_width1 2
+#property indicator_label1 "AC"
 #property version "1.000"
 #endif
+
+// This will allow calling MT5 functions in MT4.
+#define INDICATOR_LEGACY_VERSION_MT5
+#define INDICATOR_LEGACY_VERSION_LONG // OHLC-based OnCalculate().
+#define INDICATOR_LEGACY_VERSION_ACQUIRE_BUFFER ACQUIRE_BUFFER1(ExtACBuffer)
+#define INDICATOR_LEGACY_VERSION_RELEASE_BUFFER RELEASE_BUFFER1(ExtACBuffer)
+#include <EA31337-classes/IndicatorLegacy.h>
 
 // Includes the main code.
 #include "AC.mq5"

--- a/Oscillators/AC.mq5
+++ b/Oscillators/AC.mq5
@@ -36,10 +36,10 @@
 #property description INDI_FULL_NAME
 //--
 #property indicator_separate_window
-#property indicator_buffers 6
+#property indicator_buffers 2
 #property indicator_plots 1
-#property indicator_type1 DRAW_COLOR_HISTOGRAM
-#property indicator_color1 Green, Red
+#property indicator_type1 DRAW_COLOR_LINE
+#property indicator_color1 Green
 #property indicator_width1 2
 #property indicator_label1 INDI_SHORT_NAME
 #property version "1.000"
@@ -51,8 +51,11 @@
 #resource "\\Indicators\\Examples\\Accelerator.ex5"
 #endif
 
+#define __debug__
+
 // Includes.
 #include <EA31337-classes/Indicators/Indi_AC.mqh>
+#include <EA31337-classes/Platform.h>
 
 // Input parameters.
 input int InpShift = 0;                                     // Indicator shift
@@ -75,6 +78,7 @@ void OnInit() {
   // Initialize indicator.
   IndiACParams _indi_params(::InpShift);
   indi = new Indi_AC(_indi_params /* , InpSourceType */);
+  Platform::AddWithDefaultBindings(indi);
   // Name for labels.
   // @todo: Use serialized string of _indi_params.
   string short_name = StringFormat("%s", indi.GetName());

--- a/Oscillators/AC.mt5.mq4
+++ b/Oscillators/AC.mt5.mq4
@@ -30,5 +30,12 @@
 #property version "1.000"
 #endif
 
+// This will allow calling MT5 functions in MT4.
+#define INDICATOR_LEGACY_VERSION_MT5
+#define INDICATOR_LEGACY_VERSION_LONG // OHLC-based OnCalculate().
+#define INDICATOR_LEGACY_VERSION_ACQUIRE_BUFFER ACQUIRE_BUFFER1(ExtACBuffer)
+#define INDICATOR_LEGACY_VERSION_RELEASE_BUFFER RELEASE_BUFFER1(ExtACBuffer)
+#include <EA31337-classes/IndicatorLegacy.h>
+
 // Includes MQL5 version of indicator.
 #include <../Indicators\Examples\Accelerator.mq5>

--- a/Oscillators/AO.mq4
+++ b/Oscillators/AO.mq4
@@ -30,6 +30,15 @@
 #property version "1.000"
 #endif
 
+// This will allow calling MT5 functions in MT4.
+#define INDICATOR_LEGACY_VERSION_MT5
+#define INDICATOR_LEGACY_VERSION_LONG // OHLC-based OnCalculate().
+#define INDICATOR_LEGACY_VERSION_ACQUIRE_BUFFER                                \
+  ACQUIRE_BUFFER4(ExtAOBuffer, ExtColorBuffer, ExtFastBuffer, ExtSlowBuffer)
+#define INDICATOR_LEGACY_VERSION_RELEASE_BUFFER                                \
+  RELEASE_BUFFER4(ExtAOBuffer, ExtColorBuffer, ExtFastBuffer, ExtSlowBuffer)
+#include <EA31337-classes/IndicatorLegacy.h>
+
 // Includes the main code.
 #include "AO.mq5"
 

--- a/Oscillators/AO.mq5
+++ b/Oscillators/AO.mq5
@@ -115,7 +115,7 @@ int OnCalculate(const int rates_total, const int prev_calculated,
   int max_modes =
       indi.Get<int>(STRUCT_ENUM(IndicatorDataParams, IDATA_PARAM_MAX_MODES));
   */
-  uint max_modes = indi.GetParams().max_modes;
+  uint max_modes = indi.GetModeCount();
   start = prev_calculated == 0 ? fmax3(0, FAST_PERIOD, SLOW_PERIOD)
                                : prev_calculated - 1;
   // Main calculations.

--- a/Oscillators/AO.mt5.mq4
+++ b/Oscillators/AO.mt5.mq4
@@ -30,5 +30,14 @@
 #property version "1.000"
 #endif
 
+// This will allow calling MT5 functions in MT4.
+#define INDICATOR_LEGACY_VERSION_MT5
+#define INDICATOR_LEGACY_VERSION_LONG // OHLC-based OnCalculate().
+#define INDICATOR_LEGACY_VERSION_ACQUIRE_BUFFER                                \
+  ACQUIRE_BUFFER4(ExtAOBuffer, ExtColorBuffer, ExtFastBuffer, ExtSlowBuffer)
+#define INDICATOR_LEGACY_VERSION_RELEASE_BUFFER                                \
+  RELEASE_BUFFER4(ExtAOBuffer, ExtColorBuffer, ExtFastBuffer, ExtSlowBuffer)
+#include <EA31337-classes/IndicatorLegacy.h>
+
 // Includes MQL5 version of indicator.
 #include <../Indicators\Examples\Awesome_Oscillator.mq5>

--- a/Oscillators/Bears.mq4
+++ b/Oscillators/Bears.mq4
@@ -28,6 +28,13 @@
 #property version "1.000"
 #endif
 
+// This will allow calling MT5 functions in MT4.
+#define INDICATOR_LEGACY_VERSION_MT5
+#define INDICATOR_LEGACY_VERSION_LONG // OHLC-based OnCalculate().
+#define INDICATOR_LEGACY_VERSION_ACQUIRE_BUFFER ACQUIRE_BUFFER1(ExtBearsBuffer)
+#define INDICATOR_LEGACY_VERSION_RELEASE_BUFFER RELEASE_BUFFER1(ExtBearsBuffer)
+#include <EA31337-classes/IndicatorLegacy.h>
+
 // Includes the main code.
 #include "Bears.mq5"
 

--- a/Oscillators/Bears.mt5.mq4
+++ b/Oscillators/Bears.mt5.mq4
@@ -28,5 +28,12 @@
 #property version "1.000"
 #endif
 
+// This will allow calling MT5 functions in MT4.
+#define INDICATOR_LEGACY_VERSION_MT5
+#define INDICATOR_LEGACY_VERSION_LONG // OHLC-based OnCalculate().
+#define INDICATOR_LEGACY_VERSION_ACQUIRE_BUFFER ACQUIRE_BUFFER1(ExtBearsBuffer)
+#define INDICATOR_LEGACY_VERSION_RELEASE_BUFFER RELEASE_BUFFER1(ExtBearsBuffer)
+#include <EA31337-classes/IndicatorLegacy.h>
+
 // Includes MQL5 version of indicator.
 #include <../Indicators\Examples\Bears.mq5>

--- a/Oscillators/Gator.mq4
+++ b/Oscillators/Gator.mq4
@@ -35,6 +35,17 @@
 #property version "1.000"
 #endif
 
+// This will allow calling MT5 functions in MT4.
+#define INDICATOR_LEGACY_VERSION_MT5
+#define INDICATOR_LEGACY_VERSION_LONG // OHLC-based OnCalculate().
+#define INDICATOR_LEGACY_VERSION_ACQUIRE_BUFFER                                \
+  ACQUIRE_BUFFER4(ExtUpperBuffer, ExtUpColorsBuffer, ExtLowerBuffer,           \
+                  ExtLoColorsBuffer)
+#define INDICATOR_LEGACY_VERSION_RELEASE_BUFFER                                \
+  RELEASE_BUFFER4(ExtUpperBuffer, ExtUpColorsBuffer, ExtLowerBuffer,           \
+                  ExtLoColorsBuffer)
+#include <EA31337-classes/IndicatorLegacy.h>
+
 // Includes the main code.
 #include "Gator.mq5"
 

--- a/Oscillators/Gator.mq5
+++ b/Oscillators/Gator.mq5
@@ -54,12 +54,10 @@
 // Resource files.
 #ifdef __MQL5__
 #property tester_indicator "::Indicators\\Examples\\Gator.ex5"
-#ifdef __MQL5__
 #property tester_indicator "::Indicators\\Examples\\Gator_2.ex5"
-#endif
-#endif
 #resource "\\Indicators\\Examples\\Gator.ex5"
 #resource "\\Indicators\\Examples\\Gator_2.ex5"
+#endif
 
 // Includes.
 #include <EA31337-classes/Indicators/Indi_Gator.mqh>

--- a/Oscillators/Gator.mt5.mq4
+++ b/Oscillators/Gator.mt5.mq4
@@ -35,5 +35,16 @@
 #property version "1.000"
 #endif
 
+// This will allow calling MT5 functions in MT4.
+#define INDICATOR_LEGACY_VERSION_MT5
+#define INDICATOR_LEGACY_VERSION_LONG // OHLC-based OnCalculate().
+#define INDICATOR_LEGACY_VERSION_ACQUIRE_BUFFER                                \
+  ACQUIRE_BUFFER4(ExtUpperBuffer, ExtUpColorsBuffer, ExtLowerBuffer,           \
+                  ExtLoColorsBuffer)
+#define INDICATOR_LEGACY_VERSION_RELEASE_BUFFER                                \
+  RELEASE_BUFFER4(ExtUpperBuffer, ExtUpColorsBuffer, ExtLowerBuffer,           \
+                  ExtLoColorsBuffer)
+#include <EA31337-classes/IndicatorLegacy.h>
+
 // Includes MQL5 version of indicator.
 #include <../Indicators\Examples\Gator.mq5>

--- a/Oscillators/OsMA.mq4
+++ b/Oscillators/OsMA.mq4
@@ -30,6 +30,13 @@
 #property version "1.000"
 #endif
 
+// This will allow calling MT5 functions in MT4.
+#define INDICATOR_LEGACY_VERSION_MT5
+#define INDICATOR_LEGACY_VERSION_LONG // OHLC-based OnCalculate().
+#define INDICATOR_LEGACY_VERSION_ACQUIRE_BUFFER ACQUIRE_BUFFER1(ExtOsMABuffer)
+#define INDICATOR_LEGACY_VERSION_RELEASE_BUFFER RELEASE_BUFFER1(ExtOsMABuffer)
+#include <EA31337-classes/IndicatorLegacy.h>
+
 // Includes the main code.
 #include "OsMA.mq5"
 

--- a/Oscillators/OsMA.mt5.mq4
+++ b/Oscillators/OsMA.mt5.mq4
@@ -30,5 +30,12 @@
 #property version "1.000"
 #endif
 
+// This will allow calling MT5 functions in MT4.
+#define INDICATOR_LEGACY_VERSION_MT5
+#define INDICATOR_LEGACY_VERSION_LONG // OHLC-based OnCalculate().
+#define INDICATOR_LEGACY_VERSION_ACQUIRE_BUFFER ACQUIRE_BUFFER1(ExtOsMABuffer)
+#define INDICATOR_LEGACY_VERSION_RELEASE_BUFFER RELEASE_BUFFER1(ExtOsMABuffer)
+#include <EA31337-classes/IndicatorLegacy.h>
+
 // Includes MQL5 version of indicator.
 #include <../Indicators\Examples\OsMA.mq5>

--- a/Oscillators/UOS.mq4
+++ b/Oscillators/UOS.mq4
@@ -29,6 +29,13 @@
 #property version "1.000"
 #endif
 
+// This will allow calling MT5 functions in MT4.
+#define INDICATOR_LEGACY_VERSION_MT5
+#define INDICATOR_LEGACY_VERSION_LONG // OHLC-based OnCalculate().
+#define INDICATOR_LEGACY_VERSION_ACQUIRE_BUFFER ACQUIRE_BUFFER1(ExtBuffer)
+#define INDICATOR_LEGACY_VERSION_RELEASE_BUFFER RELEASE_BUFFER1(ExtBuffer)
+#include <EA31337-classes/IndicatorLegacy.h>
+
 // Includes the main code.
 #include "UOS.mq5"
 

--- a/Oscillators/UOS.mt5.mq4
+++ b/Oscillators/UOS.mt5.mq4
@@ -29,5 +29,16 @@
 #property version "1.000"
 #endif
 
+// This will allow calling MT5 functions in MT4.
+#define INDICATOR_LEGACY_VERSION_MT5
+#define INDICATOR_LEGACY_VERSION_LONG // OHLC-based OnCalculate().
+#define INDICATOR_LEGACY_VERSION_ACQUIRE_BUFFER                                \
+  ACQUIRE_BUFFER5(ExtUOBuffer, ExtBPBuffer, ExtFastATRBuffer,                  \
+                  ExtMiddleATRBuffer, ExtSlowATRBuffer)
+#define INDICATOR_LEGACY_VERSION_RELEASE_BUFFER                                \
+  RELEASE_BUFFER5(ExtUOBuffer, ExtBPBuffer, ExtFastATRBuffer,                  \
+                  ExtMiddleATRBuffer, ExtSlowATRBuffer)
+#include <EA31337-classes/IndicatorLegacy.h>
+
 // Includes MQL5 version of indicator.
 #include <../Indicators\Examples\Ultimate_Oscillator.mq5>

--- a/Oscillators/Volume/BWMFI.mt5.mq4
+++ b/Oscillators/Volume/BWMFI.mt5.mq4
@@ -30,7 +30,15 @@
 #endif
 
 // Includes EA31337 framework.
-#include <EA31337-classes/Indicator.enum.h>
+#include <EA31337-classes/DateTime.struct.h>
+#include <EA31337-classes/Indicator/Indicator.enum.h>
+
+datetime TimeTradeServer() { return DateTimeStatic::TimeTradeServer(); }
+
+#define INDICATOR_LEGACY_VERSION_ACQUIRE_BUFFER                                \
+  ACQUIRE_BUFFER4(ExtMLBuffer, ExtTLBuffer, ExtBLBuffer, ExtStdDevBuffer)
+#define INDICATOR_LEGACY_VERSION_RELEASE_BUFFER                                \
+  RELEASE_BUFFER4(ExtMLBuffer, ExtTLBuffer, ExtBLBuffer, ExtStdDevBuffer)
 
 // Includes MQL5 version of indicator.
 #include <../Indicators\Examples\MarketFacilitationIndex.mq5>

--- a/Price/MA.mq4
+++ b/Price/MA.mq4
@@ -28,6 +28,13 @@
 #property version "1.000"
 #endif
 
+// This will allow calling MT5 functions in MT4.
+#define INDICATOR_LEGACY_VERSION_MT5
+#define INDICATOR_LEGACY_VERSION_LONG // OHLC-based OnCalculate().
+#define INDICATOR_LEGACY_VERSION_ACQUIRE_BUFFER ACQUIRE_BUFFER1(ExtMABuffer)
+#define INDICATOR_LEGACY_VERSION_RELEASE_BUFFER RELEASE_BUFFER1(ExtMABuffer)
+#include <EA31337-classes/IndicatorLegacy.h>
+
 // Includes the main code.
 #include "MA.mq5"
 

--- a/Price/MA.mt5.mq4
+++ b/Price/MA.mt5.mq4
@@ -28,5 +28,12 @@
 #property version "1.000"
 #endif
 
+// This will allow calling MT5 functions in MT4.
+#define INDICATOR_LEGACY_VERSION_MT5
+#define INDICATOR_LEGACY_VERSION_SHORT // Non-OHLC OnCalculate().
+#define INDICATOR_LEGACY_VERSION_ACQUIRE_BUFFER ACQUIRE_BUFFER1(ExtLineBuffer)
+#define INDICATOR_LEGACY_VERSION_RELEASE_BUFFER RELEASE_BUFFER1(ExtLineBuffer)
+#include <EA31337-classes/IndicatorLegacy.h>
+
 // Includes MQL5 version of indicator.
 #include <../Indicators\Examples\Custom Moving Average.mq5>

--- a/Price/Multi/Alligator.mq4
+++ b/Price/Multi/Alligator.mq4
@@ -30,6 +30,15 @@
 #property version "1.000"
 #endif
 
+// This will allow calling MT5 functions in MT4.
+#define INDICATOR_LEGACY_VERSION_MT5
+#define INDICATOR_LEGACY_VERSION_LONG // OHLC-based OnCalculate().
+#define INDICATOR_LEGACY_VERSION_ACQUIRE_BUFFER                                \
+  ACQUIRE_BUFFER3(ExtJaws, ExtTeeth, ExtLips)
+#define INDICATOR_LEGACY_VERSION_RELEASE_BUFFER                                \
+  RELEASE_BUFFER3(ExtJaws, ExtTeeth, ExtLips)
+#include <EA31337-classes/IndicatorLegacy.h>
+
 // Includes the main code.
 #include "Alligator.mq5"
 

--- a/Price/Multi/Alligator.mt5.mq4
+++ b/Price/Multi/Alligator.mt5.mq4
@@ -30,6 +30,15 @@
 #property version "1.000"
 #endif
 
+// This will allow calling MT5 functions in MT4.
+#define INDICATOR_LEGACY_VERSION_MT5
+#define INDICATOR_LEGACY_VERSION_LONG // OHLC-based OnCalculate().
+#define INDICATOR_LEGACY_VERSION_ACQUIRE_BUFFER                                \
+  ACQUIRE_BUFFER3(ExtJaws, ExtTeeth, ExtLips)
+#define INDICATOR_LEGACY_VERSION_RELEASE_BUFFER                                \
+  RELEASE_BUFFER3(ExtJaws, ExtTeeth, ExtLips)
+#include <EA31337-classes/IndicatorLegacy.h>
+
 // Includes EA31337 framework.
 #include <EA31337-classes/Indicators/Indi_MA.mqh>
 

--- a/Price/Range/BB.mq4
+++ b/Price/Range/BB.mq4
@@ -30,6 +30,15 @@
 #property version "1.000"
 #endif
 
+// This will allow calling MT5 functions in MT4.
+#define INDICATOR_LEGACY_VERSION_MT5
+#define INDICATOR_LEGACY_VERSION_LONG // OHLC-based OnCalculate().
+#define INDICATOR_LEGACY_VERSION_ACQUIRE_BUFFER                                \
+  ACQUIRE_BUFFER4(ExtMLBuffer, ExtTLBuffer, ExtBLBuffer, ExtStdDevBuffer)
+#define INDICATOR_LEGACY_VERSION_RELEASE_BUFFER                                \
+  RELEASE_BUFFER4(ExtMLBuffer, ExtTLBuffer, ExtBLBuffer, ExtStdDevBuffer)
+#include <EA31337-classes/IndicatorLegacy.h>
+
 // Includes the main code.
 #include "BB.mq5"
 

--- a/Price/Range/BB.mt5.mq4
+++ b/Price/Range/BB.mt5.mq4
@@ -30,5 +30,14 @@
 #property version "1.000"
 #endif
 
+// This will allow calling MT5 functions in MT4.
+#define INDICATOR_LEGACY_VERSION_MT5
+#define INDICATOR_LEGACY_VERSION_SHORT // Non-OHLC OnCalculate().
+#define INDICATOR_LEGACY_VERSION_ACQUIRE_BUFFER                                \
+  ACQUIRE_BUFFER4(ExtMLBuffer, ExtTLBuffer, ExtBLBuffer, ExtStdDevBuffer)
+#define INDICATOR_LEGACY_VERSION_RELEASE_BUFFER                                \
+  RELEASE_BUFFER4(ExtMLBuffer, ExtTLBuffer, ExtBLBuffer, ExtStdDevBuffer)
+#include <EA31337-classes/IndicatorLegacy.h>
+
 // Includes MQL5 version of indicator.
 #include <../Indicators\Examples\BB.mq5>


### PR DESCRIPTION
- Oscillators: AC, AO, Bears, Gator, OsMA, UOS, BWMFI
- Indicators: MA, Alligator, BB. Refs #3, #6, #7, #8, #9, #10, #11, #12, #13. We need to check if MT4 version runs and draws proper data.
Requires changes from EA31337/EA31337-classes `v3.007-dev-new-mt5-code-in-mt4-indicator-support` branch.